### PR TITLE
Make interface of linear_sieve generic

### DIFF
--- a/include/boost/math/special_functions/prime_sieve.hpp
+++ b/include/boost/math/special_functions/prime_sieve.hpp
@@ -41,7 +41,6 @@ namespace detail
 template<class Integer, class OutputIterator>
 OutputIterator linear_sieve(Integer upper_bound, OutputIterator resultant_primes)
 {
-    auto const first = resultant_primes;
     auto const least_divisors_size = upper_bound + 1;
     std::unique_ptr<Integer[]> least_divisors{new Integer[least_divisors_size]{0}};
 
@@ -53,7 +52,7 @@ OutputIterator linear_sieve(Integer upper_bound, OutputIterator resultant_primes
             *resultant_primes++ = i;
         }
 
-        for (Integer j = 0; j < resultant_primes - first
+        for (Integer j = 0; j < i - 1
                             && i * resultant_primes[j] <= upper_bound
                             && resultant_primes[j] <= least_divisors[i]
                             && j < least_divisors_size;                     ++j)

--- a/reporting/performance/prime_sieve_performance.cpp
+++ b/reporting/performance/prime_sieve_performance.cpp
@@ -74,22 +74,16 @@ void interval_sieve(benchmark::State& state)
     state.SetComplexityN(state.range(0));
 }
 
-// Complete Implementations
-template<class ExecuitionPolicy, class Integer, class Container>
-inline auto prime_sieve_helper(ExecuitionPolicy policy, Integer upper, Container primes)
-{
-    boost::math::prime_sieve(policy, upper, primes);
-    return primes;
-}
-
 template <class Integer>
 void prime_sieve(benchmark::State& state)
 {
     Integer upper = static_cast<Integer>(state.range(0));
+    std::vector<Integer> primes;
+
     for(auto _ : state)
     {
-        std::vector<Integer> primes;
-        benchmark::DoNotOptimize(prime_sieve_helper(std::execution::par, upper, primes));
+        primes.clear();
+        boost::math::prime_sieve(std::execution::par, upper, primes);
     }
     state.SetComplexityN(state.range(0));
 }


### PR DESCRIPTION
I broke something in the logic, so it segfaults in the benchmark.

This is just meant to be an indication of how to make `linear_sieve` generic, it's _not_ a complete solution.
